### PR TITLE
Fixed typo in inngest.module.ts

### DIFF
--- a/src/inngest.module.ts
+++ b/src/inngest.module.ts
@@ -8,7 +8,7 @@ import { serve } from "inngest/express";
 export const INNGEST_KEY = "INNGEST" as const;
 export const INNGEST_OPTIONS = "INNGEST_OPTIONS" as const;
 export const INNGEST_FUNCTION = "INNGEST_FUNCTION" as const;
-export const INNGEST_TRIGGER = "INNGEST_FUNCTION" as const;
+export const INNGEST_TRIGGER = "INNGEST_TRIGGER" as const;
 
 export interface InngestModuleOptions {
   /**


### PR DESCRIPTION
Due to this typo, only the function decorators get collected, which results in functions that get defined with missing trigger definition.